### PR TITLE
New removeAll function to empty pool of all workers

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -20,7 +20,7 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 
     this.removeAll = function() {
         if(count > 0) {
-            for(var i = 0; i < count; i++) {
+            for(var i = count-1; i >= 0; i--) {
                 that.remove(resources.splice(i, 1)[0].resource);
             }
         }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -18,6 +18,14 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 		}
 	};
 
+    this.removeAll = function() {
+        if(count > 0) {
+            for(var i = 0; i < count; i++) {
+                that.remove(resources.splice(i, 1)[0].resource);
+            }
+        }
+    };
+
 	this.take = function(callback) {
 		if (available > 0) {
 			available--;


### PR DESCRIPTION
Awesome npm module! I've used it for a few weeks and it's exactly what I need to manage dozens of long-lived processes. 

I ran into an issue with processes that are spawned not dying when my main node.js is killed. So I added this function to kill all the processes that have been added to the pool at once. Just a simple helper function, nothing fancy.

Let me know what you think and if there's anything you'd change. I've tested it with my code and it works with no problems.
