### PR TITLE
Don't double decrement available

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -44,7 +44,6 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 
 	this.remove = function(resource) {
 		if (resource !== null) {
-			available--;
 			destroy(resource);
 			count--;
 			queue.length && that.take(queue.shift());

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -19,6 +19,11 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 		}
 	};
 
+  this.poolCount = function(){
+    return count;
+  };
+
+
 	this.take = function(callback) {
 		if (available > 0) {
 			available--;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -12,6 +12,7 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 		var time = new Date().getTime();
 		for (var i = 0; i < available; i++) {
 			if (resources[i].time + idleTimeout < time) {
+				available--;
 				that.remove(resources.splice(i, 1)[0].resource);
 				i--;
 			}
@@ -53,6 +54,7 @@ var Pool = function(create, destroy, size, idleTimeout, idleInterval) {
 	this.removeAll = function() {
 		if (available > 0) {
 			for (var i = available - 1; i >= 0; i--) {
+				available--;
 				that.remove(resources.splice(i, 1)[0].resource);
 			}
 		}


### PR DESCRIPTION
When removing a resource that was already taken we accidentally double decrement the available counter (once on the take, and again on the remove).
